### PR TITLE
Update json_api_client dependency to v1.23

### DIFF
--- a/productive.gemspec
+++ b/productive.gemspec
@@ -13,6 +13,6 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
   s.files = `git ls-files`.split("\n")
 
-  s.add_dependency 'json_api_client', '>= 1.13.0', "<= 1.21.0"
+  s.add_dependency 'json_api_client', '>= 1.13.0', "<= 1.23.0"
   s.add_dependency 'request_store', '~> 1.3'
 end


### PR DESCRIPTION
Faraday 2.x support was added in v1.23. Right now the productive gem is causing security issues on apps that include it because other gems have switched to Faraday 2.x and cannot be upgraded until productive also makes the switch.