### PR TITLE
[chore] Remove json_api_client upper bound

### DIFF
--- a/lib/productive/version.rb
+++ b/lib/productive/version.rb
@@ -1,3 +1,3 @@
 module Productive
-  VERSION = '0.6.86'.freeze
+  VERSION = '0.6.87'.freeze
 end

--- a/productive.gemspec
+++ b/productive.gemspec
@@ -13,6 +13,6 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
   s.files = `git ls-files`.split("\n")
 
-  s.add_dependency 'json_api_client', '>= 1.13.0', "<= 1.21.0"
+  s.add_dependency 'json_api_client', '>= 1.13.0'
   s.add_dependency 'request_store', '~> 1.3'
 end


### PR DESCRIPTION
## Summary
Removes the upper version constraint on json_api_client (was <= 1.21.0). Faraday 2.x support was added in json_api_client v1.23, and the old constraint was blocking apps from upgrading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)